### PR TITLE
Move key derivation to duct_hierarchy.edn

### DIFF
--- a/src/duct/compiler/sass.clj
+++ b/src/duct/compiler/sass.clj
@@ -62,8 +62,6 @@
     (.mkdirs (.getParentFile out))
     (spit out (.getCss result))))
 
-(derive :duct.compiler/sass :duct/compiler)
-
 (defmethod ig/init-key :duct.compiler/sass [_ opts]
   (let [in->out (file-mapping opts)]
     (doseq [[in out] in->out]

--- a/src/duct_hierarchy.edn
+++ b/src/duct_hierarchy.edn
@@ -1,0 +1,1 @@
+{:duct.compiler/sass [:duct/compiler]}


### PR DESCRIPTION
Register key derivation from :duct/compiler without needing an explicit require.

This makes it so running a Duct application for compilation (ie. only prepping/executing `:duct/compiler` keys) includes the SASS compiler without explicitly requiring the namespace.
