### PR TITLE
Upgrade jsass to have support for Apple Silicon hardware

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,8 @@
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [duct/logger "0.2.1"]
                  [integrant "0.6.3"]
-                 [io.bit3/jsass "5.5.6"]
+                 [io.bit3/jsass "5.11.0"]
                  [medley "1.0.0"]]
+  :profiles {:test {:dependencies [[org.clojure/data.json "2.5.0"]]}}
   :test-paths ["test" "target/test"])
 

--- a/test/duct/compiler/sass_test.clj
+++ b/test/duct/compiler/sass_test.clj
@@ -1,5 +1,6 @@
 (ns duct.compiler.sass-test
-  (:require [clojure.java.io :as io]
+  (:require [clojure.data.json :as json]
+            [clojure.java.io :as io]
             [clojure.test :refer :all]
             [duct.compiler.sass :as sass]
             [integrant.core :as ig]))
@@ -67,4 +68,5 @@
         (is (.exists actual))
         (is (.exists actual-map))
         (is (= (slurp expected) (slurp actual)))
-        (is (= (slurp expected-map) (slurp actual-map)))))))
+        (is (= (json/read-str (slurp expected-map))
+               (json/read-str (slurp actual-map))))))))

--- a/test/sass/test4.source-map.css.map
+++ b/test/sass/test4.source-map.css.map
@@ -3,7 +3,6 @@
 	"file": "test4.css",
 	"sources": [
 		"../../../test/sass/test4.scss",
-		"../../../test/sass/test4.scss/JSASS_CUSTOM.scss",
 		"../../../test/sass/_reset.scss"
 	],
 	"names": [],


### PR DESCRIPTION
The jsass version currently used by duct/compiler.sass (5.6.0) is rather old, and doesn't work on Apple Silicon hardware. This has been fixed in the latest available version[1].

Among the changes between versions 5.6.0 and 5.11.0, there is the one done in issue 79[2], where the jsass internal sources are wiped out from the source map. Also, the order of the entries in the JSON source map is not stable. So instead of "blindly" comparing the string representations of the maps on disk, we need to compare the real maps.

Hence, we need to adjust the unit tests accordingly.

Other than that, according to the jsass project changelogs, there are no breaking changes between version 5.6.0 and 5.11.0.

[1] https://gitlab.com/jsass/jsass/-/releases/5.11.0
[2] https://gitlab.com/jsass/jsass/-/issues/79